### PR TITLE
Support for optional async

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,0 @@
---require emoji-rspec
---format hearts

--- a/lib/rack/amqp/client.rb
+++ b/lib/rack/amqp/client.rb
@@ -33,5 +33,6 @@ end
 
 require "rack/amqp/client/request"
 require "rack/amqp/client/response"
+require "rack/amqp/client/null_response"
 require "rack/amqp/client/manager"
 require "rack/amqp/client/version"

--- a/lib/rack/amqp/client/manager.rb
+++ b/lib/rack/amqp/client/manager.rb
@@ -24,13 +24,17 @@ module Rack
 
           request = Request.new((@correlation_id += 1).to_s, http_method, uri, body, headers)
           @mutex.synchronize { @incomplete_requests << request }
+
           callback_queue = create_callback_queue
           request.callback_queue = callback_queue
 
           amqp_channel.direct('').publish(request.payload, request.publishing_options)
 
-          response = request.reply_wait(timeout)
-          response
+          puts "I'm async: #{!!options[:async]}"
+          unless options[:async]
+            response = request.reply_wait(timeout)
+            response
+          end
         end
 
         private
@@ -51,7 +55,7 @@ module Rack
           end
           # bind to an exchange, maybe later
           queue
-                              end
+          end
         end
 
         def connect!(broker_options)

--- a/lib/rack/amqp/client/manager.rb
+++ b/lib/rack/amqp/client/manager.rb
@@ -30,10 +30,10 @@ module Rack
 
           amqp_channel.direct('').publish(request.payload, request.publishing_options)
 
-          puts "I'm async: #{!!options[:async]}"
-          unless options[:async]
-            response = request.reply_wait(timeout)
-            response
+          if options[:async]
+            NullResponse.new
+          else
+            request.reply_wait(timeout)
           end
         end
 

--- a/lib/rack/amqp/client/null_response.rb
+++ b/lib/rack/amqp/client/null_response.rb
@@ -1,0 +1,15 @@
+module Rack
+  module AMQP
+    module Client
+      class NullResponse < Response
+        def initialize(meta = {}, payload = {}, delivery_info = nil)
+          super
+          @meta[:headers] ||= {}
+          @meta[:headers]['X-AMQP-HTTP-Status'] = 200
+        end
+      end
+    end
+  end
+end
+
+

--- a/rack-amqp-client.gemspec
+++ b/rack-amqp-client.gemspec
@@ -23,5 +23,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "emoji-rspec"
 end


### PR DESCRIPTION
For #1:

Passing `{async: true}` option prevents the current thread from waiting
for a response to appear on the callback channel.
